### PR TITLE
This commit introduces the initial implementation of the RPG module, …

### DIFF
--- a/src/main/java/com/minekarta/advancedcoresurvival/core/modules/ModuleManager.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/core/modules/ModuleManager.java
@@ -38,6 +38,7 @@ public class ModuleManager {
      */
     public void registerModules() {
         // This is where all module classes will be instantiated and added to the list.
+        modules.add(new com.minekarta.advancedcoresurvival.modules.rpg.RPGModule());
         modules.add(new com.minekarta.advancedcoresurvival.modules.essentials.EssentialsModule());
         modules.add(new com.minekarta.advancedcoresurvival.modules.economy.EconomyModule());
         modules.add(new com.minekarta.advancedcoresurvival.modules.claims.ClaimsModule());

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/RPGModule.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/RPGModule.java
@@ -1,0 +1,50 @@
+package com.minekarta.advancedcoresurvival.modules.rpg;
+
+import com.minekarta.advancedcoresurvival.core.AdvancedCoreSurvival;
+import com.minekarta.advancedcoresurvival.core.modules.Module;
+import com.minekarta.advancedcoresurvival.modules.rpg.commands.StatsCommand;
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import com.minekarta.advancedcoresurvival.modules.rpg.listeners.MiningSkillListener;
+import com.minekarta.advancedcoresurvival.modules.rpg.listeners.PlayerConnectionListener;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class RPGModule implements Module {
+
+    private PlayerStatsManager statsManager;
+
+    @Override
+    public String getName() {
+        return "rpg";
+    }
+
+    @Override
+    public void onEnable(AdvancedCoreSurvival plugin) {
+        plugin.getLogger().info("Initializing RPG Module...");
+
+        // Initialize managers
+        this.statsManager = new PlayerStatsManager();
+
+        // Register Listeners
+        plugin.getServer().getPluginManager().registerEvents(new PlayerConnectionListener(statsManager), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new MiningSkillListener(statsManager), plugin);
+
+        // Register Commands
+        plugin.getCommand("stats").setExecutor(new StatsCommand(statsManager));
+
+        // Load stats for any players who are already online (e.g., on a /reload)
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            statsManager.loadPlayerStats(player.getUniqueId());
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        // Save stats for all online players when the module is disabled
+        if (statsManager != null) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                statsManager.unloadPlayer(player.getUniqueId());
+            }
+        }
+    }
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/commands/.gitkeep
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/commands/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure that the directory is tracked by git.

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/commands/StatsCommand.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/commands/StatsCommand.java
@@ -1,0 +1,52 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.commands;
+
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStats;
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class StatsCommand implements CommandExecutor {
+
+    private final PlayerStatsManager statsManager;
+
+    public StatsCommand(PlayerStatsManager statsManager) {
+        this.statsManager = statsManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        PlayerStats stats = statsManager.getPlayerStats(player);
+
+        if (stats == null) {
+            player.sendMessage(ChatColor.RED + "Your stats could not be loaded. Please try relogging.");
+            return true;
+        }
+
+        // Format and send the stats message to the player
+        player.sendMessage(ChatColor.GOLD + "--- Your Stats ---");
+        player.sendMessage(ChatColor.YELLOW + "Level: " + ChatColor.WHITE + stats.getLevel());
+        player.sendMessage(ChatColor.YELLOW + "EXP: " + ChatColor.WHITE + String.format("%.2f", stats.getExp()));
+        player.sendMessage("");
+        player.sendMessage(ChatColor.AQUA + "Attributes:");
+        player.sendMessage(ChatColor.GRAY + " - Strength: " + ChatColor.WHITE + stats.getStrength());
+        player.sendMessage(ChatColor.GRAY + " - Agility: " + ChatColor.WHITE + stats.getAgility());
+        player.sendMessage(ChatColor.GRAY + " - Endurance: " + ChatColor.WHITE + stats.getEndurance());
+        player.sendMessage("");
+        player.sendMessage(ChatColor.GREEN + "Skills:");
+        stats.getSkillLevels().forEach((skill, level) -> {
+            player.sendMessage(ChatColor.GRAY + " - " + skill + ": " + ChatColor.WHITE + level);
+        });
+        player.sendMessage(ChatColor.GOLD + "------------------");
+
+        return true;
+    }
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/.gitkeep
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure that the directory is tracked by git.

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/PlayerStats.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/PlayerStats.java
@@ -1,0 +1,104 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.data;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A data class to hold all RPG-related statistics for a single player.
+ */
+public class PlayerStats {
+
+    private final UUID playerUUID;
+    private int level;
+    private double exp;
+
+    // Core player attributes
+    private int strength;
+    private int agility;
+    private int endurance;
+
+    // Player skills, represented as a map of skill name to skill level
+    private final Map<String, Integer> skillLevels;
+
+    /**
+     * Constructor for a new player's stats.
+     * Initializes all stats and skills to default values.
+     * @param playerUUID The UUID of the player.
+     */
+    public PlayerStats(UUID playerUUID) {
+        this.playerUUID = playerUUID;
+        this.level = 1;
+        this.exp = 0;
+        this.strength = 5;
+        this.agility = 5;
+        this.endurance = 5;
+        this.skillLevels = new HashMap<>();
+        // Initialize default skills
+        this.skillLevels.put("MINING", 1);
+        this.skillLevels.put("FARMING", 1);
+        this.skillLevels.put("WOODCUTTING", 1);
+    }
+
+    // --- Getters and Setters ---
+
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public double getExp() {
+        return exp;
+    }
+
+    public void setExp(double exp) {
+        this.exp = exp;
+    }
+
+    public void addExp(double amount) {
+        this.exp += amount;
+    }
+
+    public int getStrength() {
+        return strength;
+    }
+
+    public void setStrength(int strength) {
+        this.strength = strength;
+    }
+
+    public int getAgility() {
+        return agility;
+    }
+
+    public void setAgility(int agility) {
+        this.agility = agility;
+    }
+
+    public int getEndurance() {
+        return endurance;
+    }
+
+    public void setEndurance(int endurance) {
+        this.endurance = endurance;
+    }
+
+    public Map<String, Integer> getSkillLevels() {
+        return skillLevels;
+    }
+
+    public int getSkillLevel(String skillName) {
+        return skillLevels.getOrDefault(skillName.toUpperCase(), 0);
+    }
+
+    public void setSkillLevel(String skillName, int level) {
+        skillLevels.put(skillName.toUpperCase(), level);
+    }
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/PlayerStatsManager.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/PlayerStatsManager.java
@@ -1,0 +1,82 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.data;
+
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages the loading, saving, and accessing of PlayerStats objects.
+ * For now, this is an in-memory cache. In the future, it will connect to a database.
+ */
+public class PlayerStatsManager {
+
+    private final Map<UUID, PlayerStats> statsCache = new ConcurrentHashMap<>();
+
+    /**
+     * Retrieves the stats for a given player from the cache.
+     * If the player is not in the cache, their data is loaded.
+     *
+     * @param player The player whose stats are to be retrieved.
+     * @return The PlayerStats object for the player.
+     */
+    public PlayerStats getPlayerStats(Player player) {
+        return statsCache.computeIfAbsent(player.getUniqueId(), uuid -> loadPlayerStats(player.getUniqueId()));
+    }
+
+    /**
+     * Retrieves the stats for a given player UUID from the cache.
+     * This is useful for offline player operations if they are cached.
+     * Returns null if the player is not in the cache.
+     *
+     * @param uuid The UUID of the player.
+     * @return The PlayerStats object or null if not cached.
+     */
+    public PlayerStats getPlayerStats(UUID uuid) {
+        return statsCache.get(uuid);
+    }
+
+    /**
+     * Loads a player's stats into the cache.
+     * For now, this simply creates a new default PlayerStats object.
+     * In the future, this method will load data from a database.
+     *
+     * @param uuid The UUID of the player to load.
+     * @return The newly created PlayerStats object.
+     */
+    public PlayerStats loadPlayerStats(UUID uuid) {
+        // In the future, this would load from a database (e.g., SQLite, MySQL)
+        // For now, we just create fresh stats.
+        PlayerStats newStats = new PlayerStats(uuid);
+        statsCache.put(uuid, newStats);
+        return newStats;
+    }
+
+    /**
+     * Saves a player's stats from the cache.
+     * In the future, this will write the data to the database.
+     *
+     * @param uuid The UUID of the player to save.
+     */
+    public void savePlayerStats(UUID uuid) {
+        PlayerStats stats = statsCache.get(uuid);
+        if (stats != null) {
+            // In the future, save the 'stats' object to the database here.
+            System.out.println("Simulating save for player " + uuid);
+        }
+    }
+
+    /**
+     * Saves and removes a player's stats from the cache.
+     * This should be called when a player quits the server.
+     *
+     * @param uuid The UUID of the player to unload.
+     */
+    public void unloadPlayer(UUID uuid) {
+        savePlayerStats(uuid);
+        statsCache.remove(uuid);
+    }
+
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/.gitkeep
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure that the directory is tracked by git.

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/MiningSkillListener.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/MiningSkillListener.java
@@ -1,0 +1,65 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.listeners;
+
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStats;
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Listener for mining-related actions to grant EXP.
+ */
+public class MiningSkillListener implements Listener {
+
+    private final PlayerStatsManager statsManager;
+    private final Map<Material, Double> expValues = new HashMap<>();
+
+    public MiningSkillListener(PlayerStatsManager statsManager) {
+        this.statsManager = statsManager;
+        // Define EXP values for different blocks
+        expValues.put(Material.COAL_ORE, 5.0);
+        expValues.put(Material.IRON_ORE, 10.0);
+        expValues.put(Material.GOLD_ORE, 15.0);
+        expValues.put(Material.DIAMOND_ORE, 25.0);
+        expValues.put(Material.EMERALD_ORE, 30.0);
+        expValues.put(Material.LAPIS_ORE, 8.0);
+        expValues.put(Material.REDSTONE_ORE, 8.0);
+        expValues.put(Material.NETHER_QUARTZ_ORE, 7.0);
+        expValues.put(Material.STONE, 0.5);
+        expValues.put(Material.ANDESITE, 0.5);
+        expValues.put(Material.DIORITE, 0.5);
+        expValues.put(Material.GRANITE, 0.5);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+
+        // Only grant EXP if the player is in survival mode
+        if (player.getGameMode() != GameMode.SURVIVAL) {
+            return;
+        }
+
+        Block block = event.getBlock();
+        double expToGrant = expValues.getOrDefault(block.getType(), 0.0);
+
+        if (expToGrant > 0) {
+            PlayerStats stats = statsManager.getPlayerStats(player);
+            if (stats != null) {
+                stats.addExp(expToGrant);
+                // Optional: Send a message to the player
+                // player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent("+" + expToGrant + " Mining EXP"));
+
+                // TODO: Add level up logic
+            }
+        }
+    }
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/PlayerConnectionListener.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/PlayerConnectionListener.java
@@ -1,0 +1,33 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.listeners;
+
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles loading and unloading of player stats when they connect or disconnect.
+ */
+public class PlayerConnectionListener implements Listener {
+
+    private final PlayerStatsManager statsManager;
+
+    public PlayerConnectionListener(PlayerStatsManager statsManager) {
+        this.statsManager = statsManager;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        // Asynchronously load the player's stats into the cache.
+        // The getPlayerStats method in the manager handles the initial loading.
+        statsManager.getPlayerStats(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        // Unload the player's stats from the cache to save memory.
+        // The manager will handle saving the data before removing it.
+        statsManager.unloadPlayer(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -77,6 +77,10 @@ commands:
     description: Open the Admin Shop.
     aliases: [ashop]
     permission: advancedcoresurvival.economy.adminshop
+  stats:
+    description: Displays your RPG stats.
+    usage: /stats
+    permission: advancedcoresurvival.rpg.stats
   rpg:
     description: View your RPG stats and skills.
     permission: advancedcoresurvival.rpg.base
@@ -147,6 +151,9 @@ permissions:
     default: true
   advancedcoresurvival.rpg.base:
     description: Base permission for the /rpg command.
+    default: true
+  advancedcoresurvival.rpg.stats:
+    description: Allows a player to view their own stats.
     default: true
   advancedcoresurvival.mmorpg.*:
     description: Grants access to all MMORPG features.


### PR DESCRIPTION
…as outlined in Section A of the project analysis.

It lays the groundwork for the RPG system by adding the following:
- A new `rpg` module that can be enabled or disabled.
- A `PlayerStats` data class to store player level, EXP, attributes, and skills.
- A `PlayerStatsManager` to handle the lifecycle of player data using an in-memory cache.
- A `MiningSkillListener` that grants players EXP for breaking ore and stone blocks.
- A `PlayerConnectionListener` to manage loading and unloading player data on join/quit.
- A new `/stats` command that allows players to view their current RPG information.

The module is integrated into the core plugin, registered in the ModuleManager, and the new command and permissions are added to plugin.yml.