### PR TITLE
feat(rpg): Implement player leveling system

### DIFF
--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/RPGModule.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/RPGModule.java
@@ -4,14 +4,18 @@ import com.minekarta.advancedcoresurvival.core.AdvancedCoreSurvival;
 import com.minekarta.advancedcoresurvival.core.modules.Module;
 import com.minekarta.advancedcoresurvival.modules.rpg.commands.StatsCommand;
 import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import com.minekarta.advancedcoresurvival.modules.rpg.leveling.LevelingManager;
+import com.minekarta.advancedcoresurvival.modules.rpg.listeners.FarmingSkillListener;
 import com.minekarta.advancedcoresurvival.modules.rpg.listeners.MiningSkillListener;
 import com.minekarta.advancedcoresurvival.modules.rpg.listeners.PlayerConnectionListener;
+import com.minekarta.advancedcoresurvival.modules.rpg.listeners.WoodcuttingSkillListener;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 public class RPGModule implements Module {
 
     private PlayerStatsManager statsManager;
+    private LevelingManager levelingManager;
 
     @Override
     public String getName() {
@@ -24,10 +28,13 @@ public class RPGModule implements Module {
 
         // Initialize managers
         this.statsManager = new PlayerStatsManager();
+        this.levelingManager = new LevelingManager(statsManager, plugin.getConfig());
 
         // Register Listeners
         plugin.getServer().getPluginManager().registerEvents(new PlayerConnectionListener(statsManager), plugin);
-        plugin.getServer().getPluginManager().registerEvents(new MiningSkillListener(statsManager), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new MiningSkillListener(levelingManager), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new FarmingSkillListener(levelingManager), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new WoodcuttingSkillListener(levelingManager), plugin);
 
         // Register Commands
         plugin.getCommand("stats").setExecutor(new StatsCommand(statsManager));

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/leveling/LevelingManager.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/leveling/LevelingManager.java
@@ -1,0 +1,147 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.leveling;
+
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStats;
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+public class LevelingManager {
+
+    private final PlayerStatsManager statsManager;
+    private final double baseExp;
+    private final double expMultiplier;
+    private final String levelUpMessage;
+    private final String expGainActionBar;
+
+    public LevelingManager(PlayerStatsManager statsManager, FileConfiguration config) {
+        this.statsManager = statsManager;
+
+        // Load settings from config
+        this.baseExp = config.getDouble("rpg.leveling.base-exp", 1000.0);
+        this.expMultiplier = config.getDouble("rpg.leveling.exp-multiplier", 1.2);
+        this.levelUpMessage = config.getString("rpg.leveling.level-up-message", "&a&lCongratulations, %player_name%! You have reached Level %new_level%!");
+        this.expGainActionBar = config.getString("rpg.leveling.exp-gain-action-bar", "&b+%gained_exp% EXP &7[&a%exp_bar%&7] &e%current_exp%&7/&e%required_exp%");
+    }
+
+    /**
+     * Calculates the total EXP required to reach a certain level.
+     * @param level The level to calculate the required EXP for.
+     * @return The total EXP required.
+     */
+    public double getRequiredExp(int level) {
+        if (level <= 1) {
+            return 0;
+        }
+        // Formula: base * (multiplier ^ (level - 2))
+        // We use level - 2 because level 2 should use the base_exp (multiplier^0)
+        return baseExp * Math.pow(expMultiplier, level - 2);
+    }
+
+    /**
+     * Checks if a player has enough EXP to level up and processes the level up if they do.
+     * This can handle multiple level-ups in one go.
+     * @param player The player to check.
+     */
+    public void checkAndPromote(Player player) {
+        PlayerStats stats = statsManager.getPlayerStats(player);
+        if (stats == null) return;
+
+        double requiredExp = getRequiredExp(stats.getLevel() + 1);
+
+        // Loop in case they gain enough EXP for multiple levels
+        while (stats.getExp() >= requiredExp) {
+            // Level up!
+            stats.setLevel(stats.getLevel() + 1);
+            stats.setExp(stats.getExp() - requiredExp);
+
+            // Send level up message
+            if (levelUpMessage != null && !levelUpMessage.isEmpty()) {
+                String message = ChatColor.translateAlternateColorCodes('&', levelUpMessage
+                        .replace("%player_name%", player.getName())
+                        .replace("%new_level%", String.valueOf(stats.getLevel())));
+                player.sendMessage(message);
+            }
+
+            // TODO: Add sound effects or other rewards here in the future.
+
+            // Get the requirement for the next level
+            requiredExp = getRequiredExp(stats.getLevel() + 1);
+        }
+    }
+
+    /**
+     * Call this method after adding EXP to a player.
+     * It will check for level up and send an action bar message.
+     * @param player The player who gained EXP.
+     * @param amountGained The amount of EXP they just gained.
+     */
+    public void onExpGain(Player player, double amountGained) {
+        PlayerStats stats = statsManager.getPlayerStats(player);
+        if (stats == null) return;
+
+        // Add the experience
+        stats.addExp(amountGained);
+
+        // Check for level up
+        checkAndPromote(player);
+
+        // Send action bar message
+        sendExpActionBar(player, amountGained);
+    }
+
+    /**
+     * Sends the EXP gain action bar message to the player.
+     * @param player The player to send the message to.
+     * @param gainedAmount The amount of EXP the player just gained.
+     */
+    public void sendExpActionBar(Player player, double gainedAmount) {
+        if (expGainActionBar == null || expGainActionBar.isEmpty()) {
+            return;
+        }
+
+        PlayerStats stats = statsManager.getPlayerStats(player);
+        if (stats == null) return;
+
+        double currentExp = stats.getExp();
+        double requiredExp = getRequiredExp(stats.getLevel() + 1);
+
+        String message = expGainActionBar
+                .replace("%gained_exp%", String.format("%.1f", gainedAmount))
+                .replace("%current_exp%", String.format("%.1f", currentExp))
+                .replace("%required_exp%", String.format("%.0f", requiredExp));
+
+        // Create the EXP bar
+        message = message.replace("%exp_bar%", createProgressBar(currentExp, requiredExp));
+
+        // Using spigot API to send action bar messages
+        // Note: This needs to be compiled against Spigot/Paper API
+        // For now, let's just send it as a regular message for compatibility.
+        // In a real scenario, you would use Adventure or Spigot's Chat API.
+        player.sendActionBar(LegacyComponentSerializer.legacyAmpersand().deserialize(message));
+    }
+
+    /**
+     * Creates a textual progress bar.
+     * @param current The current value.
+     * @param max The maximum value.
+     * @return A string representing the progress bar.
+     */
+    private String createProgressBar(double current, double max) {
+        if (max <= 0) return "-------";
+
+        int barLength = 10; // The total number of characters in the bar
+        int progress = (int) ((current / max) * barLength);
+
+        StringBuilder bar = new StringBuilder();
+        for (int i = 0; i < barLength; i++) {
+            if (i < progress) {
+                bar.append(ChatColor.GREEN + "|");
+            } else {
+                bar.append(ChatColor.GRAY + "|");
+            }
+        }
+        return bar.toString();
+    }
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/FarmingSkillListener.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/FarmingSkillListener.java
@@ -4,6 +4,7 @@ import com.minekarta.advancedcoresurvival.modules.rpg.leveling.LevelingManager;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -13,36 +14,26 @@ import org.bukkit.event.block.BlockBreakEvent;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Listener for mining-related actions to grant EXP.
- */
-public class MiningSkillListener implements Listener {
+public class FarmingSkillListener implements Listener {
 
     private final LevelingManager levelingManager;
     private final Map<Material, Double> expValues = new HashMap<>();
 
-    public MiningSkillListener(LevelingManager levelingManager) {
+    public FarmingSkillListener(LevelingManager levelingManager) {
         this.levelingManager = levelingManager;
-        // Define EXP values for different blocks
-        expValues.put(Material.COAL_ORE, 5.0);
-        expValues.put(Material.IRON_ORE, 10.0);
-        expValues.put(Material.GOLD_ORE, 15.0);
-        expValues.put(Material.DIAMOND_ORE, 25.0);
-        expValues.put(Material.EMERALD_ORE, 30.0);
-        expValues.put(Material.LAPIS_ORE, 8.0);
-        expValues.put(Material.REDSTONE_ORE, 8.0);
-        expValues.put(Material.NETHER_QUARTZ_ORE, 7.0);
-        expValues.put(Material.STONE, 0.5);
-        expValues.put(Material.ANDESITE, 0.5);
-        expValues.put(Material.DIORITE, 0.5);
-        expValues.put(Material.GRANITE, 0.5);
+        // Define EXP values for different crops
+        expValues.put(Material.WHEAT, 4.0);
+        expValues.put(Material.CARROTS, 4.0);
+        expValues.put(Material.POTATOES, 4.0);
+        expValues.put(Material.BEETROOTS, 4.0);
+        expValues.put(Material.NETHER_WART, 5.0);
+        expValues.put(Material.PUMPKIN, 8.0);
+        expValues.put(Material.MELON, 8.0);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
-
-        // Only grant EXP if the player is in survival mode
         if (player.getGameMode() != GameMode.SURVIVAL) {
             return;
         }
@@ -51,6 +42,16 @@ public class MiningSkillListener implements Listener {
         double expToGrant = expValues.getOrDefault(block.getType(), 0.0);
 
         if (expToGrant > 0) {
+            // For ageable crops, only grant EXP if they are fully grown
+            if (block.getBlockData() instanceof Ageable) {
+                Ageable ageable = (Ageable) block.getBlockData();
+                if (ageable.getAge() != ageable.getMaximumAge()) {
+                    return; // Not fully grown, no EXP
+                }
+            }
+
+            // For pumpkins and melons, they are not ageable, so they grant EXP directly.
+
             levelingManager.onExpGain(player, expToGrant);
         }
     }

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/WoodcuttingSkillListener.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/WoodcuttingSkillListener.java
@@ -1,0 +1,40 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.listeners;
+
+import com.minekarta.advancedcoresurvival.modules.rpg.leveling.LevelingManager;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WoodcuttingSkillListener implements Listener {
+
+    private final LevelingManager levelingManager;
+    private final double expPerLog = 6.0;
+
+    public WoodcuttingSkillListener(LevelingManager levelingManager) {
+        this.levelingManager = levelingManager;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        if (player.getGameMode() != GameMode.SURVIVAL) {
+            return;
+        }
+
+        Block block = event.getBlock();
+
+        // Use the LOGS tag to identify all types of logs easily.
+        if (Tag.LOGS.isTagged(block.getType())) {
+            levelingManager.onExpGain(player, expPerLog);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -95,3 +95,20 @@ claims:
       pvp: false
       fire-spread: false
       mob-griefing: false
+
+rpg:
+  leveling:
+    # The formula used is: required_exp_for_next_level = base-exp * (multiplier ^ (current_level - 1))
+    # Example: To get from level 1 to 2, you need 'base-exp'. To get from 2 to 3, you need 'base-exp * multiplier'.
+    base-exp: 1000
+    # How much harder each level gets. 1.2 means 20% harder than the last.
+    # Set to 1.0 for linear progression (same exp for every level).
+    exp-multiplier: 1.2
+    # --- Messages ---
+    # Message sent to the player when they level up.
+    # Placeholders: %player_name%, %new_level%
+    level-up-message: "&a&lCongratulations, %player_name%! You have reached Level %new_level%!"
+    # Message shown in the action bar when a player gains EXP.
+    # Placeholders: %gained_exp%, %current_exp%, %required_exp%, %exp_bar%
+    # Set to "" to disable.
+    exp-gain-action-bar: "&b+%gained_exp% EXP &7[&a%exp_bar%&7] &e%current_exp%&7/&e%required_exp%"


### PR DESCRIPTION
This commit introduces a comprehensive leveling system to the RPG module. Players can now level up by gaining experience points (EXP) from various activities.

Key features include:
- A configurable leveling curve with a base EXP and multiplier.
- EXP gain from Mining, Farming, and Woodcutting.
- A `LevelingManager` to centralize all leveling logic.
- Action bar messages to provide players with instant feedback on EXP gains, including a progress bar.
- Configurable chat messages for level-up announcements.

The implementation is designed to be extensible for future EXP sources.