### PR TITLE
feat(rpg): Implement combat EXP and stat effects

### DIFF
--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/commands/StatsCommand.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/commands/StatsCommand.java
@@ -41,6 +41,8 @@ public class StatsCommand implements CommandExecutor {
         player.sendMessage(ChatColor.GRAY + " - Agility: " + ChatColor.WHITE + stats.getAgility());
         player.sendMessage(ChatColor.GRAY + " - Endurance: " + ChatColor.WHITE + stats.getEndurance());
         player.sendMessage("");
+        player.sendMessage(ChatColor.LIGHT_PURPLE + "Skill Points: " + ChatColor.WHITE + stats.getSkillPoints());
+        player.sendMessage("");
         player.sendMessage(ChatColor.GREEN + "Skills:");
         stats.getSkillLevels().forEach((skill, level) -> {
             player.sendMessage(ChatColor.GRAY + " - " + skill + ": " + ChatColor.WHITE + level);

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/PlayerStats.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/data/PlayerStats.java
@@ -17,6 +17,7 @@ public class PlayerStats {
     private int strength;
     private int agility;
     private int endurance;
+    private int skillPoints;
 
     // Player skills, represented as a map of skill name to skill level
     private final Map<String, Integer> skillLevels;
@@ -33,6 +34,7 @@ public class PlayerStats {
         this.strength = 5;
         this.agility = 5;
         this.endurance = 5;
+        this.skillPoints = 0;
         this.skillLevels = new HashMap<>();
         // Initialize default skills
         this.skillLevels.put("MINING", 1);
@@ -88,6 +90,18 @@ public class PlayerStats {
 
     public void setEndurance(int endurance) {
         this.endurance = endurance;
+    }
+
+    public int getSkillPoints() {
+        return skillPoints;
+    }
+
+    public void setSkillPoints(int skillPoints) {
+        this.skillPoints = skillPoints;
+    }
+
+    public void addSkillPoints(int amount) {
+        this.skillPoints += amount;
     }
 
     public Map<String, Integer> getSkillLevels() {

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/leveling/LevelingManager.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/leveling/LevelingManager.java
@@ -12,6 +12,7 @@ public class LevelingManager {
     private final PlayerStatsManager statsManager;
     private final double baseExp;
     private final double expMultiplier;
+    private final int skillPointsPerLevel;
     private final String levelUpMessage;
     private final String expGainActionBar;
 
@@ -21,6 +22,7 @@ public class LevelingManager {
         // Load settings from config
         this.baseExp = config.getDouble("rpg.leveling.base-exp", 1000.0);
         this.expMultiplier = config.getDouble("rpg.leveling.exp-multiplier", 1.2);
+        this.skillPointsPerLevel = config.getInt("rpg.leveling.skill-points-per-level", 1);
         this.levelUpMessage = config.getString("rpg.leveling.level-up-message", "&a&lCongratulations, %player_name%! You have reached Level %new_level%!");
         this.expGainActionBar = config.getString("rpg.leveling.exp-gain-action-bar", "&b+%gained_exp% EXP &7[&a%exp_bar%&7] &e%current_exp%&7/&e%required_exp%");
     }
@@ -54,6 +56,7 @@ public class LevelingManager {
         while (stats.getExp() >= requiredExp) {
             // Level up!
             stats.setLevel(stats.getLevel() + 1);
+            stats.addSkillPoints(skillPointsPerLevel);
             stats.setExp(stats.getExp() - requiredExp);
 
             // Send level up message

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/CombatSkillListener.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/CombatSkillListener.java
@@ -1,0 +1,79 @@
+package com.minekarta.advancedcoresurvival.modules.rpg.listeners;
+
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStats;
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
+import com.minekarta.advancedcoresurvival.modules.rpg.leveling.LevelingManager;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Listener for combat-related actions to grant EXP and apply stat effects.
+ */
+public class CombatSkillListener implements Listener {
+
+    private final LevelingManager levelingManager;
+    private final PlayerStatsManager statsManager;
+    private final Map<EntityType, Double> expValues;
+    private final double damagePerStrength;
+    private final double dodgeChancePerAgility;
+
+    public CombatSkillListener(LevelingManager levelingManager, PlayerStatsManager statsManager, Map<EntityType, Double> expValues, double damagePerStrength, double dodgeChancePerAgility) {
+        this.levelingManager = levelingManager;
+        this.statsManager = statsManager;
+        this.expValues = expValues;
+        this.damagePerStrength = damagePerStrength;
+        this.dodgeChancePerAgility = dodgeChancePerAgility;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityDeath(EntityDeathEvent event) {
+        // Only grant EXP if the killer is a player
+        if (event.getEntity().getKiller() == null) {
+            return;
+        }
+
+        Player player = event.getEntity().getKiller();
+        EntityType entityType = event.getEntityType();
+
+        double expToGrant = expValues.getOrDefault(entityType, 0.0);
+
+        if (expToGrant > 0) {
+            levelingManager.onExpGain(player, expToGrant);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        // --- Agility (Dodge Chance) ---
+        if (event.getEntity() instanceof Player) {
+            Player victim = (Player) event.getEntity();
+            PlayerStats victimStats = statsManager.getPlayerStats(victim);
+            if (victimStats != null) {
+                double dodgeChance = victimStats.getAgility() * dodgeChancePerAgility;
+                if (ThreadLocalRandom.current().nextDouble() < dodgeChance) {
+                    event.setCancelled(true);
+                    // TODO: Add a "dodge" message or sound effect
+                    return; // Stop processing damage if dodged
+                }
+            }
+        }
+
+        // --- Strength (Damage Bonus) ---
+        if (event.getDamager() instanceof Player) {
+            Player attacker = (Player) event.getDamager();
+            PlayerStats attackerStats = statsManager.getPlayerStats(attacker);
+            if (attackerStats != null) {
+                double bonusDamage = attackerStats.getStrength() * damagePerStrength;
+                event.setDamage(event.getDamage() + bonusDamage);
+            }
+        }
+    }
+}

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/PlayerConnectionListener.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/listeners/PlayerConnectionListener.java
@@ -22,6 +22,8 @@ public class PlayerConnectionListener implements Listener {
         // Asynchronously load the player's stats into the cache.
         // The getPlayerStats method in the manager handles the initial loading.
         statsManager.getPlayerStats(event.getPlayer());
+        // Update their health based on their stats
+        statsManager.updatePlayerHealth(event.getPlayer());
     }
 
     @EventHandler

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -104,6 +104,8 @@ rpg:
     # How much harder each level gets. 1.2 means 20% harder than the last.
     # Set to 1.0 for linear progression (same exp for every level).
     exp-multiplier: 1.2
+    # The number of skill points awarded to a player each time they level up.
+    skill-points-per-level: 1
     # --- Messages ---
     # Message sent to the player when they level up.
     # Placeholders: %player_name%, %new_level%
@@ -112,3 +114,18 @@ rpg:
     # Placeholders: %gained_exp%, %current_exp%, %required_exp%, %exp_bar%
     # Set to "" to disable.
     exp-gain-action-bar: "&b+%gained_exp% EXP &7[&a%exp_bar%&7] &e%current_exp%&7/&e%required_exp%"
+  stats:
+    # The bonus damage applied per point of Strength.
+    damage-per-strength: 0.5
+    # The chance to dodge an attack per point of Agility (0.01 = 1%).
+    dodge-chance-per-agility: 0.005
+    # The amount of extra health (in half hearts) per point of Endurance.
+    health-per-endurance: 1.0
+  exp-rewards:
+    combat:
+      ZOMBIE: 10.0
+      SKELETON: 10.0
+      SPIDER: 8.0
+      CREEPER: 15.0
+      ENDERMAN: 20.0
+      BLAZE: 25.0


### PR DESCRIPTION
This commit introduces two major features to the RPG module:

1.  **Combat EXP:** Players now gain experience points for killing mobs. The amount of EXP gained is configurable in `config.yml` for each mob type. A new `CombatSkillListener` has been added to handle this.

2.  **Stat Effects:** The core player attributes (Strength, Agility, Endurance) now have tangible effects on gameplay:
    *   **Strength:** Increases the damage dealt by the player.
    *   **Agility:** Provides a chance to dodge incoming attacks.
    *   **Endurance:** Increases the player's maximum health.
    The effectiveness of each stat is configurable in `config.yml`.

3.  **Skill Points:** Players are now awarded a configurable number of skill points upon leveling up. This lays the groundwork for a future skill tree system. The `/stats` command has been updated to display available skill points.