### PR TITLE
Fix: Resolve VaultAPI dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
             <id>placeholderapi-repo</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
The build was failing because Maven could not resolve the VaultAPI dependency. This was because the JitPack repository, where the dependency is hosted, was not included in the `pom.xml`.

This change adds the JitPack repository to the `pom.xml`, which allows Maven to find and download the VaultAPI dependency, resolving the build error.