### PR TITLE
feat: Implement and complete core plugin features

### DIFF
--- a/src/main/java/com/minekarta/advancedcoresurvival/core/storage/Storage.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/core/storage/Storage.java
@@ -1,6 +1,7 @@
 package com.minekarta.advancedcoresurvival.core.storage;
 
 import com.minekarta.advancedcoresurvival.core.AdvancedCoreSurvival;
+import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStats;
 import org.bukkit.Location;
 
 import java.util.List;
@@ -21,8 +22,8 @@ public interface Storage {
     boolean isConnected();
 
     // --- Economy ---
-    CompletableFuture<Double> getPlayerBalance(UUID playerUUID);
-    CompletableFuture<Void> setPlayerBalance(UUID playerUUID, double balance);
+    CompletableFuture<Double> getPlayerBalance(UUID playerUUID, String worldName);
+    CompletableFuture<Void> setPlayerBalance(UUID playerUUID, String worldName, double balance);
 
     // --- Essentials (Spawn) ---
     CompletableFuture<Void> setSpawnLocation(Location location);
@@ -48,4 +49,20 @@ public interface Storage {
     CompletableFuture<Boolean> isMemberOfClaim(int claimId, UUID memberUUID);
     CompletableFuture<List<UUID>> getClaimMembers(int claimId);
     CompletableFuture<Integer> getClaimCount(UUID ownerUUID);
+
+    // --- RPG ---
+    CompletableFuture<Void> savePlayerStats(PlayerStats stats);
+    CompletableFuture<PlayerStats> loadPlayerStats(UUID playerUUID);
+
+    // --- Banks ---
+    CompletableFuture<Boolean> hasBank(String name);
+    CompletableFuture<Boolean> createBank(String name, UUID owner);
+    CompletableFuture<Boolean> deleteBank(String name);
+    CompletableFuture<Double> getBankBalance(String name);
+    CompletableFuture<Void> setBankBalance(String name, double balance);
+    CompletableFuture<Boolean> isBankOwner(String name, UUID player);
+    CompletableFuture<Boolean> isBankMember(String name, UUID player);
+    CompletableFuture<Void> addBankMember(String name, UUID player);
+    CompletableFuture<Void> removeBankMember(String name, UUID player);
+    CompletableFuture<List<String>> getBanks();
 }

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/claims/ClaimsModule.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/claims/ClaimsModule.java
@@ -29,6 +29,10 @@ public class ClaimsModule implements Module {
         plugin.getServer().getPluginManager().registerEvents(new ClaimProtectionListener(plugin), plugin);
     }
 
+    public ClaimTaxManager getTaxManager() {
+        return taxManager;
+    }
+
     @Override
     public void onDisable() {
         if (taxManager != null) {

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/claims/tax/ClaimTaxManager.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/claims/tax/ClaimTaxManager.java
@@ -45,7 +45,7 @@ public class ClaimTaxManager {
         }
     }
 
-    private void collectTaxes() {
+    public void collectTaxes() {
         plugin.getLogger().info("Starting daily claim tax collection...");
         double taxPerChunk = plugin.getConfig().getDouble("claims.internal.tax.cost-per-chunk-per-day");
 

--- a/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/RPGModule.java
+++ b/src/main/java/com/minekarta/advancedcoresurvival/modules/rpg/RPGModule.java
@@ -2,6 +2,7 @@ package com.minekarta.advancedcoresurvival.modules.rpg;
 
 import com.minekarta.advancedcoresurvival.core.AdvancedCoreSurvival;
 import com.minekarta.advancedcoresurvival.core.modules.Module;
+import com.minekarta.advancedcoresurvival.core.storage.Storage;
 import com.minekarta.advancedcoresurvival.modules.rpg.commands.RPGCommand;
 import com.minekarta.advancedcoresurvival.modules.rpg.data.PlayerStatsManager;
 import com.minekarta.advancedcoresurvival.modules.rpg.leveling.LevelingManager;
@@ -30,8 +31,11 @@ public class RPGModule implements Module {
     public void onEnable(AdvancedCoreSurvival plugin) {
         plugin.getLogger().info("Initializing RPG Module...");
 
+        // Get storage manager
+        Storage storage = plugin.getStorageManager().getStorage();
+
         // Initialize managers
-        this.statsManager = new PlayerStatsManager(plugin.getConfig());
+        this.statsManager = new PlayerStatsManager(plugin.getConfig(), storage);
         this.skillManager = new SkillManager(plugin);
         this.levelingManager = new LevelingManager(statsManager, plugin.getConfig());
 
@@ -52,6 +56,10 @@ public class RPGModule implements Module {
         for (Player player : Bukkit.getOnlinePlayers()) {
             statsManager.getPlayerStats(player);
         }
+    }
+
+    public PlayerStatsManager getStatsManager() {
+        return statsManager;
     }
 
     @Override


### PR DESCRIPTION
This commit addresses several incomplete and unimplemented features across the plugin, significantly improving its functionality and stability.

- **RPG Stats Persistence:** The RPG player statistics system is now connected to the SQLite database. Player stats are loaded on join and saved on quit, ensuring data persistence across server restarts.

- **Refactor Claim Tax Command:** The `/acs runtax` admin command has been refactored to remove the use of Java Reflection. It now uses a proper getter, making the code safer and more maintainable.

- **Vault Economy Enhancements:**
  - **Multi-world Support:** The economy system now fully supports per-world balances.
  - **Bank Support:** The Vault bank API is now fully implemented, allowing for the creation and management of in-game banks.

- **Expanded Admin Commands:** A new `/acs stats` command has been added to allow administrators to view and modify player RPG stats, which is essential for managing the newly persistent data.